### PR TITLE
updated the page idle condition

### DIFF
--- a/pageidle.c
+++ b/pageidle.c
@@ -84,7 +84,7 @@ u8 nr_active(u8 nr_pfns, u8 pfns[])
 		if (pread(fd, &entry, sizeof(entry), PFN_TO_IPF_IDX(pfn))
 				!= sizeof(entry))
 			err(2, "%s: read bitmap", __func__);
-		if (BIT_AT(entry, pfn % 64))
+		if (!BIT_AT(entry, pfn % 64))               /* bit 1 indicates idle */
 			nr_activepages++;
 	}
 	close(fd);


### PR DESCRIPTION
in pageidle.c line 87
`if (BIT_AT(entry, pfn % 64)) nr_activepages++;`
for BIT_AT() is used to check the x bit of entry is 1 (see pageidle.c line 10).
but in "/sys/kernel/mm/page_idle/bitmap" ,the 1 indicates the page is idle.
To count the active pages, the bit should be checked to see if it is 0.
so the if condition should be :
`if (!BIT_AT(entry, pfn % 64))`
